### PR TITLE
Fix lock=false never reaching terraform plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.1.10
+
+BUG FIXES:
+
+* `terraform-plan`: the `lock` param's string comparison only matched the
+  literal word `false`, but CircleCI stringifies a boolean `false` to `0` when
+  materializing an `environment:` block — so `lock: false` never actually
+  reached `terraform plan` as `-lock=false`. Now matches both renderings.
+
 ## 0.1.9
 
 ENHANCEMENTS:

--- a/src/scripts/terraform_plan.sh
+++ b/src/scripts/terraform_plan.sh
@@ -60,6 +60,7 @@ TFPlan() {
     done
   fi
 
+  # CircleCI stringifies a boolean `false` param to "0" here, not "false".
   if [[ "${I_LOCK}" == "false" || "${I_LOCK}" == "0" ]]; then
     PLAN_ARGS="$PLAN_ARGS -lock=false"
   fi

--- a/src/scripts/terraform_plan.sh
+++ b/src/scripts/terraform_plan.sh
@@ -31,6 +31,12 @@ SetupEnv() {
   echo "I_PATH"="${I_PATH}"
   echo "I_VAR"="${I_VAR}"
   echo "I_VAR_FILE"="${I_VAR_FILE}"
+  # This echo is load-bearing, not just consistency with the params above it:
+  # it's the only thing that caught I_LOCK arriving as "0" instead of "false"
+  # (CircleCI stringifies boolean params when materializing `environment:`).
+  # Every other check available - orb validate, shellcheck, config process,
+  # config validate, a green job - passed on that broken behavior. Don't
+  # remove it as noise.
   echo "I_LOCK"="${I_LOCK}"
 }
 

--- a/src/scripts/terraform_plan.sh
+++ b/src/scripts/terraform_plan.sh
@@ -31,9 +31,6 @@ SetupEnv() {
   echo "I_PATH"="${I_PATH}"
   echo "I_VAR"="${I_VAR}"
   echo "I_VAR_FILE"="${I_VAR_FILE}"
-  # Load-bearing: the only artifact showing how I_LOCK actually arrives at the
-  # shell. CircleCI stringifies boolean params, so `false` becomes "0" - every
-  # compile-time check passes either way. Don't remove as noise.
   echo "I_LOCK"="${I_LOCK}"
 }
 

--- a/src/scripts/terraform_plan.sh
+++ b/src/scripts/terraform_plan.sh
@@ -31,12 +31,9 @@ SetupEnv() {
   echo "I_PATH"="${I_PATH}"
   echo "I_VAR"="${I_VAR}"
   echo "I_VAR_FILE"="${I_VAR_FILE}"
-  # This echo is load-bearing, not just consistency with the params above it:
-  # it's the only thing that caught I_LOCK arriving as "0" instead of "false"
-  # (CircleCI stringifies boolean params when materializing `environment:`).
-  # Every other check available - orb validate, shellcheck, config process,
-  # config validate, a green job - passed on that broken behavior. Don't
-  # remove it as noise.
+  # Load-bearing: the only artifact showing how I_LOCK actually arrives at the
+  # shell. CircleCI stringifies boolean params, so `false` becomes "0" - every
+  # compile-time check passes either way. Don't remove as noise.
   echo "I_LOCK"="${I_LOCK}"
 }
 

--- a/src/scripts/terraform_plan.sh
+++ b/src/scripts/terraform_plan.sh
@@ -60,7 +60,7 @@ TFPlan() {
     done
   fi
 
-  if [[ "${I_LOCK}" == "false" ]]; then
+  if [[ "${I_LOCK}" == "false" || "${I_LOCK}" == "0" ]]; then
     PLAN_ARGS="$PLAN_ARGS -lock=false"
   fi
 


### PR DESCRIPTION
Follow-up to #3. Reviewer on GoCarrot/Carrot#2182 pulled the actual plan log rather than trusting the green checkmark and found `I_LOCK=0` in the runtime output, not `false` — CircleCI stringifies a boolean `false` to `0` when materializing an `environment:` block into real env vars (same reason `aws_oidc_assume.sh` already compares `I_FORCE_ASSUMPTION` against `"1"` rather than `"true"`). The `lock` param's comparison only matched the literal word `false`, so `-lock=false` never reached `terraform plan` — every plan using `lock: false` was still taking the state lock, which was the entire point of the param.

Fix: match both renderings, keeping the fail-safe direction (anything unrecognized leaves the lock on):

```bash
if [[ "${I_LOCK}" == "false" || "${I_LOCK}" == "0" ]]; then
```

**Why this one shipped past orb validate, shellcheck, `circleci config process`, `circleci config validate`, and a green CircleCI job:** all five of those checks operate at or above the compiled-config layer, where a boolean param is still a boolean. The bug only exists at the layer that actually executes — the shell receiving a stringified env var — and nothing upstream of that layer can see it. The `I_LOCK` echo in `SetupEnv` (added during #3's review purely for consistency with the other params) is the only artifact produced by the executing layer, and it's the only reason this was caught before merge instead of after. It's marked load-bearing in-source now; please don't remove it as debug noise in a future cleanup — it's the sole detector for this entire class of bug (a param that threads correctly through every compile-time check but arrives at the shell as something the comparison doesn't match).

`rake test` (validate + shellcheck) passes — as it did before this fix, which is exactly the point.

Needs a publish + promote to 0.1.10 before carrot's PR can be re-verified.

🤖 Generated with [Claude Code](https://claude.ai/code)