### PR TITLE
Log the built terraform plan argument string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ BUG FIXES:
   materializing an `environment:` block — so `lock: false` never actually
   reached `terraform plan` as `-lock=false`. Now matches both renderings.
 
+ENHANCEMENTS:
+
+* `terraform-plan`: logs the fully-built `terraform plan` argument string
+  before running it, so a param like `lock` can be confirmed reaching the
+  actual invocation rather than inferred from the env-var echo alone.
+
 ## 0.1.9
 
 ENHANCEMENTS:

--- a/src/scripts/terraform_plan.sh
+++ b/src/scripts/terraform_plan.sh
@@ -65,6 +65,11 @@ TFPlan() {
     PLAN_ARGS="$PLAN_ARGS -lock=false"
   fi
 
+  # PLAN_ARGS is built only from flags and I_VAR/I_VAR_FILE values already
+  # echoed above, so this carries nothing through CircleCI's masking that
+  # isn't already in the log.
+  echo "[INFO] terraform plan args: ${PLAN_ARGS}"
+
   mkdir -p "${I_OUT_PATH}"
   set +e
   # PLAN_ARGS here cannot be quoted, we are relying on the word splitting behavior


### PR DESCRIPTION
Follow-up to #4. Reviewer found that the `I_LOCK` echo (added in #3, load-bearing for finding #4's bug) shows the *input* a param arrived as, not whether it affected the actual `terraform plan` invocation — `I_LOCK=0` reads identically whether the `-lock=false` branch fired or not, since it's upstream of that decision. That means the carrot#2182 re-verify would have had no runtime artifact to confirm the fix actually took effect, only code-reading next to a green check.

Logs `PLAN_ARGS` after it's fully assembled, right before the `terraform plan` invocation:

```bash
echo "[INFO] terraform plan args: ${PLAN_ARGS}"
```

Confirmed this introduces no new masking exposure: `PLAN_ARGS` is built only from static flags plus `I_VAR`/`I_VAR_FILE` values, both already echoed earlier in the same script. CircleCI's secret masking operates by-value across the whole step log, not per-echo-line, so nothing here is any less masked than it already is. Also not piped through `tee`, so it lands in the CircleCI step log only — never in `${I_OUT_LOG}`, which is what `store_artifacts` uploads.

`rake test` (validate + shellcheck) passes.

Rides the same 0.1.10 publish as #4 — not published separately, to save alex a second publish/promote cycle today.

🤖 Generated with [Claude Code](https://claude.ai/code)