### PR TITLE
Make src/scripts/ sourceable and add a behavioral test harness

### DIFF
--- a/lib/script_harness.rb
+++ b/lib/script_harness.rb
@@ -17,29 +17,17 @@
 require 'shellwords'
 require 'timeout'
 
-# Runs behavioral tests against the actual files in src/scripts/ by sourcing
-# them in a real bash subprocess -- never by re-implementing their logic in
-# Ruby. A hand-transcribed "replica" of a script can only tell you the
-# replica is right; a faithful transcription and a subtly wrong one look
-# identical from outside.
+# Sources a script from src/scripts/ in a real bash subprocess and runs
+# behavior against it, rather than reimplementing the script in Ruby.
 module ScriptHarness
   SCRIPTS_DIR = File.expand_path('../src/scripts', __dir__)
-
-  # These scripts should never need real I/O just to be sourced -- if one
-  # hangs, its source guard is almost certainly missing or broken.
   DEFAULT_TIMEOUT = 5
 
   Result = Struct.new(:stdout, :stderr, :status)
 
   class TimeoutError < StandardError; end
 
-  # Sources `script` (a basename under src/scripts/) and then runs
-  # `bash_code` -- which may call the functions/variables the script just
-  # defined -- in that same bash process. `env` supplies the I_* variables a
-  # CircleCI `environment:` block would set before the real script runs.
-  # `chdir`, if given, runs the whole thing with that directory as cwd -- lets
-  # a caller assert nothing was left behind by a top-level side effect that
-  # doesn't print anything.
+  # `chdir`, if given, runs with that directory as cwd.
   def self.source(script, bash_code, env: {}, timeout: DEFAULT_TIMEOUT, chdir: nil)
     script_path = File.join(SCRIPTS_DIR, script)
     raise ArgumentError, "No such script: #{script_path}" unless File.file?(script_path)
@@ -72,7 +60,6 @@ module ScriptHarness
       Process.kill('KILL', -pid)
       Process.wait(pid)
     rescue Errno::ESRCH, Errno::ECHILD
-      # already gone
     end
     raise TimeoutError, "script hung past #{timeout}s -- did it lose its source guard?"
   end

--- a/lib/script_harness.rb
+++ b/lib/script_harness.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Copyright 2026 Teak.io, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'shellwords'
+require 'timeout'
+
+# Runs behavioral tests against the actual files in src/scripts/ by sourcing
+# them in a real bash subprocess -- never by re-implementing their logic in
+# Ruby. A hand-transcribed "replica" of a script can only tell you the
+# replica is right; a faithful transcription and a subtly wrong one look
+# identical from outside (see PR #5's review of the 0.1.10 fix).
+module ScriptHarness
+  SCRIPTS_DIR = File.expand_path('../src/scripts', __dir__)
+
+  # These scripts should never need real I/O just to be sourced -- if one
+  # hangs, its source guard is almost certainly missing or broken.
+  DEFAULT_TIMEOUT = 5
+
+  Result = Struct.new(:stdout, :stderr, :status)
+
+  class TimeoutError < StandardError; end
+
+  # Sources `script` (a basename under src/scripts/) and then runs
+  # `bash_code` -- which may call the functions/variables the script just
+  # defined -- in that same bash process. `env` supplies the I_* variables a
+  # CircleCI `environment:` block would set before the real script runs.
+  def self.source(script, bash_code, env: {}, timeout: DEFAULT_TIMEOUT)
+    script_path = File.join(SCRIPTS_DIR, script)
+    raise ArgumentError, "No such script: #{script_path}" unless File.file?(script_path)
+
+    full_command = "source #{script_path.shellescape}\n#{bash_code}"
+    run(['bash', '-e', '-o', 'pipefail', '-c', full_command], env: env, timeout: timeout)
+  end
+
+  def self.run(cmd, env:, timeout:)
+    stdout_r, stdout_w = IO.pipe
+    stderr_r, stderr_w = IO.pipe
+    pid = Process.spawn(env, *cmd, out: stdout_w, err: stderr_w, pgroup: true)
+    stdout_w.close
+    stderr_w.close
+
+    status = wait_with_timeout(pid, timeout)
+    Result.new(stdout_r.read, stderr_r.read, status)
+  ensure
+    stdout_r&.close
+    stderr_r&.close
+  end
+  private_class_method :run
+
+  def self.wait_with_timeout(pid, timeout)
+    Timeout.timeout(timeout, TimeoutError) { Process.wait2(pid).last }
+  rescue TimeoutError
+    begin
+      Process.kill('KILL', -pid)
+      Process.wait(pid)
+    rescue Errno::ESRCH, Errno::ECHILD
+      # already gone
+    end
+    raise TimeoutError, "script hung past #{timeout}s -- did it lose its source guard?"
+  end
+  private_class_method :wait_with_timeout
+end

--- a/lib/script_harness.rb
+++ b/lib/script_harness.rb
@@ -21,7 +21,7 @@ require 'timeout'
 # them in a real bash subprocess -- never by re-implementing their logic in
 # Ruby. A hand-transcribed "replica" of a script can only tell you the
 # replica is right; a faithful transcription and a subtly wrong one look
-# identical from outside (see PR #5's review of the 0.1.10 fix).
+# identical from outside.
 module ScriptHarness
   SCRIPTS_DIR = File.expand_path('../src/scripts', __dir__)
 
@@ -37,18 +37,23 @@ module ScriptHarness
   # `bash_code` -- which may call the functions/variables the script just
   # defined -- in that same bash process. `env` supplies the I_* variables a
   # CircleCI `environment:` block would set before the real script runs.
-  def self.source(script, bash_code, env: {}, timeout: DEFAULT_TIMEOUT)
+  # `chdir`, if given, runs the whole thing with that directory as cwd -- lets
+  # a caller assert nothing was left behind by a top-level side effect that
+  # doesn't print anything.
+  def self.source(script, bash_code, env: {}, timeout: DEFAULT_TIMEOUT, chdir: nil)
     script_path = File.join(SCRIPTS_DIR, script)
     raise ArgumentError, "No such script: #{script_path}" unless File.file?(script_path)
 
     full_command = "source #{script_path.shellescape}\n#{bash_code}"
-    run(['bash', '-e', '-o', 'pipefail', '-c', full_command], env: env, timeout: timeout)
+    run(['bash', '-e', '-o', 'pipefail', '-c', full_command], env: env, timeout: timeout, chdir: chdir)
   end
 
-  def self.run(cmd, env:, timeout:)
+  def self.run(cmd, env:, timeout:, chdir: nil)
     stdout_r, stdout_w = IO.pipe
     stderr_r, stderr_w = IO.pipe
-    pid = Process.spawn(env, *cmd, out: stdout_w, err: stderr_w, pgroup: true)
+    spawn_opts = { out: stdout_w, err: stderr_w, pgroup: true }
+    spawn_opts[:chdir] = chdir if chdir
+    pid = Process.spawn(env, *cmd, **spawn_opts)
     stdout_w.close
     stderr_w.close
 

--- a/lib/script_harness.rb
+++ b/lib/script_harness.rb
@@ -17,8 +17,6 @@
 require 'shellwords'
 require 'timeout'
 
-# Sources a script from src/scripts/ in a real bash subprocess and runs
-# behavior against it, rather than reimplementing the script in Ruby.
 module ScriptHarness
   SCRIPTS_DIR = File.expand_path('../src/scripts', __dir__)
   DEFAULT_TIMEOUT = 5
@@ -27,7 +25,6 @@ module ScriptHarness
 
   class TimeoutError < StandardError; end
 
-  # `chdir`, if given, runs with that directory as cwd.
   def self.source(script, bash_code, env: {}, timeout: DEFAULT_TIMEOUT, chdir: nil)
     script_path = File.join(SCRIPTS_DIR, script)
     raise ArgumentError, "No such script: #{script_path}" unless File.file?(script_path)

--- a/spec/script_sourcing_spec.rb
+++ b/spec/script_sourcing_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Copyright 2026 Teak.io, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../lib/script_harness'
+
+# Every script in src/scripts/ ends with a bare top-level invocation
+# (SetupEnv, then whatever does the real work) so that CircleCI's
+# `<< include(...) >>` mechanism can drop the whole file into a `run` step's
+# `command:` and have it just go. That's incompatible with sourcing the file
+# to test it behaviorally -- sourcing must define the functions without
+# running them. This is the only coverage that invocability change gets.
+RSpec.describe 'src/scripts/*.sh source guards' do
+  scripts = Dir.glob(File.join(ScriptHarness::SCRIPTS_DIR, '*.sh')).map { |path| File.basename(path) }.sort
+
+  it 'found scripts to check' do
+    expect(scripts).not_to be_empty
+  end
+
+  scripts.each do |script|
+    it "#{script}: sourcing defines SetupEnv but runs nothing" do
+      result = ScriptHarness.source(script, 'echo "SETUPENV_DEFINED=$(type -t SetupEnv)"')
+
+      expect(result.status).to be_success, "sourcing failed (stderr: #{result.stderr})"
+      expect(result.stdout.lines.map(&:chomp)).to eq(['SETUPENV_DEFINED=function']),
+        "sourcing #{script} produced unexpected output -- top-level code likely ran:\n" \
+        "stdout: #{result.stdout.inspect}\nstderr: #{result.stderr.inspect}"
+    end
+  end
+end

--- a/spec/script_sourcing_spec.rb
+++ b/spec/script_sourcing_spec.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 require_relative '../lib/script_harness'
+require 'tmpdir'
 
 # Every script in src/scripts/ ends with a bare top-level invocation
 # (SetupEnv, then whatever does the real work) so that CircleCI's
@@ -30,13 +31,18 @@ RSpec.describe 'src/scripts/*.sh source guards' do
   end
 
   scripts.each do |script|
-    it "#{script}: sourcing defines SetupEnv but runs nothing" do
-      result = ScriptHarness.source(script, 'echo "SETUPENV_DEFINED=$(type -t SetupEnv)"')
+    it "#{script}: sourcing defines SetupEnv, runs nothing, leaves nothing behind" do
+      Dir.mktmpdir('c-1292-source-guard') do |cwd|
+        result = ScriptHarness.source(script, 'echo "SETUPENV_DEFINED=$(type -t SetupEnv)"', chdir: cwd)
 
-      expect(result.status).to be_success, "sourcing failed (stderr: #{result.stderr})"
-      expect(result.stdout.lines.map(&:chomp)).to eq(['SETUPENV_DEFINED=function']),
-        "sourcing #{script} produced unexpected output -- top-level code likely ran:\n" \
-        "stdout: #{result.stdout.inspect}\nstderr: #{result.stderr.inspect}"
+        expect(result.status).to be_success, "sourcing failed (stderr: #{result.stderr})"
+        expect(result.stderr).to eq(''), "sourcing #{script} wrote to stderr: #{result.stderr.inspect}"
+        expect(result.stdout.lines.map(&:chomp)).to eq(['SETUPENV_DEFINED=function']),
+          "sourcing #{script} produced unexpected stdout -- top-level code likely ran:\n" \
+          "stdout: #{result.stdout.inspect}"
+        expect(Dir.empty?(cwd)).to be(true),
+          "sourcing #{script} left files in its cwd -- top-level code likely ran: #{Dir.children(cwd).inspect}"
+      end
     end
   end
 end

--- a/spec/script_sourcing_spec.rb
+++ b/spec/script_sourcing_spec.rb
@@ -17,12 +17,6 @@
 require_relative '../lib/script_harness'
 require 'tmpdir'
 
-# Every script in src/scripts/ ends with a bare top-level invocation
-# (SetupEnv, then whatever does the real work) so that CircleCI's
-# `<< include(...) >>` mechanism can drop the whole file into a `run` step's
-# `command:` and have it just go. That's incompatible with sourcing the file
-# to test it behaviorally -- sourcing must define the functions without
-# running them. This is the only coverage that invocability change gets.
 RSpec.describe 'src/scripts/*.sh source guards' do
   scripts = Dir.glob(File.join(ScriptHarness::SCRIPTS_DIR, '*.sh')).map { |path| File.basename(path) }.sort
 
@@ -32,7 +26,7 @@ RSpec.describe 'src/scripts/*.sh source guards' do
 
   scripts.each do |script|
     it "#{script}: sourcing defines SetupEnv, runs nothing, leaves nothing behind" do
-      Dir.mktmpdir('c-1292-source-guard') do |cwd|
+      Dir.mktmpdir('source-guard') do |cwd|
         result = ScriptHarness.source(script, 'echo "SETUPENV_DEFINED=$(type -t SetupEnv)"', chdir: cwd)
 
         expect(result.status).to be_success, "sourcing failed (stderr: #{result.stderr})"

--- a/spec/terraform_plan_spec.rb
+++ b/spec/terraform_plan_spec.rb
@@ -18,17 +18,9 @@ require_relative '../lib/script_harness'
 require 'tmpdir'
 require 'fileutils'
 
-# Source the real terraform-plan arg assembly, feed it every I_LOCK
-# rendering CircleCI can produce, and assert on terraform's
-# actual argv -- not on PLAN_ARGS in isolation. `~/terraform/terraform` is a
-# hardcoded path in the script, so this stubs terraform by pointing HOME at
-# a fixture directory rather than touching the shipped script -- TFPlan runs
-# completely unmodified, real assembly and all, and the assertion covers the
-# unquoted `$PLAN_ARGS` word-splitting at the call site along with the
-# conditional that builds it.
 RSpec.describe 'terraform_plan.sh (behavioral)' do
   around do |example|
-    Dir.mktmpdir('c-1292-terraform-plan') do |fixture_root|
+    Dir.mktmpdir('terraform-plan-fixture') do |fixture_root|
       @fixture_root = fixture_root
 
       terraform_dir = File.join(fixture_root, 'terraform')
@@ -69,9 +61,7 @@ RSpec.describe 'terraform_plan.sh (behavioral)' do
     result.stdout[/^FAKE_TERRAFORM_ARGS:(.*)$/, 1] || raise("terraform stub was never invoked:\n#{result.stdout}")
   end
 
-  # I_LOCK => whether terraform's argv should contain -lock=false.
-  # CircleCI stringifies a boolean `false` param to "0", not "false" --
-  # both must unlock; everything else must leave the state lock in place.
+  # CircleCI stringifies a boolean `false` param to "0", not "false".
   {
     '0' => true,
     'false' => true,

--- a/spec/terraform_plan_spec.rb
+++ b/spec/terraform_plan_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# Copyright 2026 Teak.io, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../lib/script_harness'
+require 'tmpdir'
+require 'fileutils'
+
+# Seed case from C-1292: source the real terraform-plan arg assembly, feed
+# it every I_LOCK rendering CircleCI can produce, and assert on terraform's
+# actual argv -- not on PLAN_ARGS in isolation. `~/terraform/terraform` is a
+# hardcoded path in the script, so this stubs terraform by pointing HOME at
+# a fixture directory rather than touching the shipped script -- TFPlan runs
+# completely unmodified, real assembly and all, and the assertion covers the
+# unquoted `$PLAN_ARGS` word-splitting at the call site along with the
+# conditional that builds it.
+RSpec.describe 'terraform_plan.sh (behavioral)' do
+  around do |example|
+    Dir.mktmpdir('c-1292-terraform-plan') do |fixture_root|
+      @fixture_root = fixture_root
+
+      terraform_dir = File.join(fixture_root, 'terraform')
+      FileUtils.mkdir_p(terraform_dir)
+      fake_terraform = File.join(terraform_dir, 'terraform')
+      File.write(fake_terraform, <<~BASH)
+        #!/usr/bin/env bash
+        echo "FAKE_TERRAFORM_ARGS:$*"
+        exit 0
+      BASH
+      FileUtils.chmod(0o755, fake_terraform)
+
+      @tf_path = File.join(fixture_root, 'module')
+      FileUtils.mkdir_p(@tf_path)
+      @out_path = File.join(fixture_root, 'out')
+
+      example.run
+    end
+  end
+
+  def plan_args_for(i_lock)
+    env = {
+      'HOME' => @fixture_root,
+      'I_OUT_PLAN' => 'plan.out',
+      'I_OUT_LOG' => 'plan.log',
+      'I_OUT_PATH' => @out_path,
+      'I_WORKSPACE' => '',
+      'I_PATH' => @tf_path,
+      'I_VAR' => '',
+      'I_VAR_FILE' => '',
+      'I_LOCK' => i_lock
+    }
+    result = ScriptHarness.source('terraform_plan.sh', 'SetupEnv; TFPlan', env: env)
+    unless result.status.success?
+      raise "TFPlan failed (status #{result.status.exitstatus}):\nstdout: #{result.stdout}\nstderr: #{result.stderr}"
+    end
+
+    result.stdout[/^FAKE_TERRAFORM_ARGS:(.*)$/, 1] || raise("terraform stub was never invoked:\n#{result.stdout}")
+  end
+
+  # I_LOCK => whether terraform's argv should contain -lock=false.
+  # CircleCI stringifies a boolean `false` param to "0", not "false" --
+  # both must unlock; everything else must leave the state lock in place.
+  {
+    '0' => true,
+    'false' => true,
+    '1' => false,
+    'true' => false,
+    '' => false,
+    'FALSE' => false,
+    'no' => false
+  }.each do |i_lock, expect_lock_false|
+    it "I_LOCK=#{i_lock.inspect}: terraform's argv #{expect_lock_false ? 'contains' : 'omits'} -lock=false" do
+      args = plan_args_for(i_lock)
+
+      if expect_lock_false
+        expect(args).to include('-lock=false')
+      else
+        expect(args).not_to include('-lock=false')
+      end
+    end
+  end
+end

--- a/spec/terraform_plan_spec.rb
+++ b/spec/terraform_plan_spec.rb
@@ -18,8 +18,8 @@ require_relative '../lib/script_harness'
 require 'tmpdir'
 require 'fileutils'
 
-# Seed case from C-1292: source the real terraform-plan arg assembly, feed
-# it every I_LOCK rendering CircleCI can produce, and assert on terraform's
+# Source the real terraform-plan arg assembly, feed it every I_LOCK
+# rendering CircleCI can produce, and assert on terraform's
 # actual argv -- not on PLAN_ARGS in isolation. `~/terraform/terraform` is a
 # hardcoded path in the script, so this stubs terraform by pointing HOME at
 # a fixture directory rather than touching the shipped script -- TFPlan runs

--- a/src/scripts/ami_update_continue_params.sh
+++ b/src/scripts/ami_update_continue_params.sh
@@ -40,5 +40,7 @@ BuildParams() {
   echo "$PARAMS" | tee continue_params.json
 }
 
-SetupEnv
-BuildParams
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  BuildParams
+fi

--- a/src/scripts/aws_oidc_assume.sh
+++ b/src/scripts/aws_oidc_assume.sh
@@ -48,10 +48,12 @@ PersistEnvVars() {
   } >> "${BASH_ENV}"
 }
 
-if [ -z "$AWS_ACCESS_KEY_ID" ] || [ "${I_FORCE_ASSUMPTION}" == "1" ]; then
-  SetupEnv
-  AssumeRole
-  PersistEnvVars
-else
-  echo "AWS_ACCESS_KEY_ID is set. Not assuming OIDC role."
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if [ -z "$AWS_ACCESS_KEY_ID" ] || [ "${I_FORCE_ASSUMPTION}" == "1" ]; then
+    SetupEnv
+    AssumeRole
+    PersistEnvVars
+  else
+    echo "AWS_ACCESS_KEY_ID is set. Not assuming OIDC role."
+  fi
 fi

--- a/src/scripts/build_dependent_images.sh
+++ b/src/scripts/build_dependent_images.sh
@@ -65,7 +65,9 @@ ExecuteCommands() {
   fi
 }
 
-SetupEnv
-IdentifyDependents
-BuildCommands
-ExecuteCommands
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  IdentifyDependents
+  BuildCommands
+  ExecuteCommands
+fi

--- a/src/scripts/deploy_or_cancel.sh
+++ b/src/scripts/deploy_or_cancel.sh
@@ -74,11 +74,13 @@ BuildInput() {
   fi
 }
 
-SetupEnv
-if [ "$I_ACTION" = "deploy" ]; then
-  GetAmiId
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  if [ "$I_ACTION" = "deploy" ]; then
+    GetAmiId
+  fi
+  GetRoleAndSfnArn
+  BuildInput
+  AssumeRole
+  Execute
 fi
-GetRoleAndSfnArn
-BuildInput
-AssumeRole
-Execute

--- a/src/scripts/generate_continue.sh
+++ b/src/scripts/generate_continue.sh
@@ -343,5 +343,7 @@ set -e
   echo "${TEMPLATE}" | tee "${I_OUT_PATH}"
 }
 
-SetupEnv
-GenerateContinue
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  GenerateContinue
+fi

--- a/src/scripts/hashicorp_install.sh
+++ b/src/scripts/hashicorp_install.sh
@@ -64,5 +64,7 @@ InstallTool() {
   fi
 }
 
-SetupEnv
-InstallTool
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  InstallTool
+fi

--- a/src/scripts/packer_build.sh
+++ b/src/scripts/packer_build.sh
@@ -57,5 +57,7 @@ PackerBuild() {
   PACKER_LOG=$I_PACKER_LOG ~/packer/packer build $BUILD_ARGS "${I_PATH}" | tee "${I_OUT_PATH}/${I_OUT_LOG}"
 }
 
-SetupEnv
-PackerBuild
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  PackerBuild
+fi

--- a/src/scripts/packer_init.sh
+++ b/src/scripts/packer_init.sh
@@ -29,5 +29,7 @@ PackerInit() {
   ~/packer/packer init "${I_PATH}"
 }
 
-SetupEnv
-PackerInit
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  PackerInit
+fi

--- a/src/scripts/slack_deployomat_cancel_on_hold_message.sh
+++ b/src/scripts/slack_deployomat_cancel_on_hold_message.sh
@@ -53,5 +53,7 @@ BuildMessage() {
     echo "export ${I_TEMPLATE_NAME}=\$(cat /tmp/teak-orb/deploy-cancel-slack-template.json)" >> "${BASH_ENV}"
 }
 
-SetupEnv
-BuildMessage
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  BuildMessage
+fi

--- a/src/scripts/slack_deployomat_deploy_on_hold_message.sh
+++ b/src/scripts/slack_deployomat_deploy_on_hold_message.sh
@@ -53,5 +53,7 @@ BuildMessage() {
     echo "export ${I_TEMPLATE_NAME}=\$(cat /tmp/teak-orb/deploy-deploy-slack-template.json)" >> "${BASH_ENV}"
 }
 
-SetupEnv
-BuildMessage
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  BuildMessage
+fi

--- a/src/scripts/terraform_init.sh
+++ b/src/scripts/terraform_init.sh
@@ -29,5 +29,7 @@ TFInit() {
   ~/terraform/terraform -chdir="${I_PATH}" init -no-color | tee /tmp/tf_init.out
 }
 
-SetupEnv
-TFInit
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  TFInit
+fi

--- a/src/scripts/terraform_plan.sh
+++ b/src/scripts/terraform_plan.sh
@@ -86,5 +86,7 @@ TFPlan() {
   fi
 }
 
-SetupEnv
-TFPlan
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  TFPlan
+fi

--- a/src/scripts/terraform_plan_continuation.sh
+++ b/src/scripts/terraform_plan_continuation.sh
@@ -93,6 +93,8 @@ GenerateContinuation() {
   echo "$CONTINUE_PARAMS" > "${I_OUT_PATH}"/continue_params.json
 }
 
-SetupEnv
-CheckEnvironmentActive
-GenerateContinuation
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  CheckEnvironmentActive
+  GenerateContinuation
+fi

--- a/src/scripts/terraform_slack_on_hold_message.sh
+++ b/src/scripts/terraform_slack_on_hold_message.sh
@@ -53,5 +53,7 @@ BuildMessage() {
     echo "export ${I_TEMPLATE_NAME}=\$(cat /tmp/teak-orb/tf-plan-slack-template.json)" >> "${BASH_ENV}"
 }
 
-SetupEnv
-BuildMessage
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  BuildMessage
+fi

--- a/src/scripts/terraform_workspace.sh
+++ b/src/scripts/terraform_workspace.sh
@@ -31,5 +31,7 @@ SetupWorkspace() {
   fi
 }
 
-SetupEnv
-SetupWorkspace
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SetupEnv
+  SetupWorkspace
+fi


### PR DESCRIPTION
[teak-buildomat-orb-worker-c-1292]

Closes C-1292

## What

1. Guards every script in `src/scripts/` so its top-level invocation only fires when the interpreter runs the file directly (as CircleCI's `<< include(...) >>` does today) and not when the file is sourced.
2. Adds a small harness (`lib/script_harness.rb`) that sources the real files in a bash subprocess to test them behaviorally — no hand-transcribed replicas.
3. Generic coverage for the guard sweep itself: every script gets sourced against a fresh empty directory, asserted to define `SetupEnv`, print nothing else, write nothing to stderr, and leave that directory empty.
4. The issue's seed case: `terraform_plan.sh`'s I_LOCK → `-lock=false` table, 7 renderings, asserted against terraform's actual argv via a stubbed `~/terraform/terraform` (script itself is untouched).

## Notable choices

- **Stub over refactor** for the terraform_plan seed case: rather than extracting the arg-assembly into its own function, this points `HOME` at a fixture dir holding a fake `terraform` binary that records its argv. Zero change to the shipped script, and it covers the unquoted `$PLAN_ARGS` word-splitting at the actual call site, not just the conditional that builds it.
- `src/scripts/packer_build.sh` is orphaned (nothing includes it — `packer-build.yml` inlines an equivalent script directly instead). Guarded it for consistency with the rest; not otherwise touched.
- No CHANGELOG entry — this is test-only, no behavior change for consumers of the orb.

## Scope of the guard-sweep spec

`spec/script_sourcing_spec.rb`'s empty-directory check catches a silent top-level side effect only if it writes a *relative* path into cwd. It does not catch an absolute-path write (e.g. `/tmp/...`), a network call, or environment mutation with no filesystem trace. It closes the gap for the shapes of regression today's 15 scripts are likely to produce, not every possible one — read it as that, not as a general guarantee that sourcing a script can have no effect.

## Testing

`rake test` (validate + shellcheck + spec) is green, 34 examples (`changelog_gate_spec` 11, `script_sourcing_spec` 16, `terraform_plan_spec` 7). Confirmed red-first throughout:
- The generic sourcing spec failed on all 15 scripts before the guards existed (real side effects — one script wrote a `continue_params.json` into cwd).
- Deliberately broke the I_LOCK conditional and confirmed the seed test caught exactly that one case, nothing else.
- Appended an unguarded relative-path `touch` to a script and confirmed the hardened guard spec catches it.