### PR TITLE
Add CircleCI config to run rake test on every push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2.1
+
+orbs:
+  circleci-cli: circleci/circleci-cli@0.1.11
+
+jobs:
+  test:
+    docker:
+      - image: cimg/ruby:3.3.9
+    steps:
+      - checkout
+      - circleci-cli/install
+      - run:
+          name: Install shellcheck
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y shellcheck
+      - run:
+          name: Install rspec
+          command: gem install rspec --no-document
+      - run:
+          name: Run test suite
+          command: rake test
+
+workflows:
+  test:
+    jobs:
+      - test


### PR DESCRIPTION
Refs C-1608

`rake test` (orb validate + shellcheck + rspec) only ran when someone remembered to run it locally. This adds `.circleci/config.yml`: a single job on `cimg/ruby:3.3.9` that installs the `circleci` CLI (official `circleci/circleci-cli@0.1.11` orb, no context/token needed — confirmed `circleci orb validate` runs fine offline/unauthenticated), shellcheck, and rspec, then runs `rake test`. No branch filters, so it runs on every push and PR.

Not in scope here: a `Gemfile`/bundler (repo doesn't have one today, separate concern), dependency caching, or pinning the circleci-cli version (defaults to `latest`; its only use is `orb validate`/`orb pack`, low blast radius).

**Known gap, can't be closed from this PR:** this repo's CircleCI project has never been set up — it isn't followed (`following: false`, `has_usable_key: false`) and has zero pipelines in its history, on any branch. Pushing this config produces no build until that's done, which needs org-level access we don't have. After that, `main` also needs this check marked required, or a red run still won't block a merge. This PR lands the config; it doesn't make the suite gate anything yet. Leaving C-1608 open until a pipeline has actually run against this config.

Verified locally:
- `rake test` green (11 examples, 0 failures; shellcheck clean; orb valid)
- `circleci config validate .circleci/config.yml` — valid
- Red-before-green on the underlying rake tasks: broke rspec (flipped an expectation), shellcheck (introduced an unquoted multi-word var), and orb validate (malformed YAML) one at a time, confirmed each failed (`git diff --stat` non-empty, task exited non-zero) before reverting. This shows `rake test`'s tasks can go red — the CircleCI job itself hasn't executed anywhere yet (no Docker locally to run `cimg/ruby:3.3.9`), so treat the job as unverified until the project is wired up.